### PR TITLE
Поправил размер выделяемой для внутренностей ффайлов памяти

### DIFF
--- a/lab1/archive.h
+++ b/lab1/archive.h
@@ -7,13 +7,12 @@
  * sprintDir - рекурсивно пишет информацию о папке в файл
  * @param filedescr - дескриптор файла
  * @param dir - название папки
- * @param str - указатель буффер
  * @param jason - указатель на структуру папки
  * @param count - указатель на счетчик кол-ва записей в файле
  * @param deep - глубина текущей папки
  * @return - код успеха операции
  */
-int sprintDir(int filedescr, char *dir, char *str, json *jason, unsigned int *count, int deep);
+int sprintDir(int filedescr, char *dir, json *jason, unsigned int *count, int deep);
 
 /**
  * Функция архивирует указанную папку


### PR DESCRIPTION
-----

- Теперь память под внууттренности должна выделятся соответственно размеру самого файла

- Сигнатура функции sprintDir изменена: теперь не нужно подавать буфер при вызове. Он будет выделяться внутри функции для соответствия размерам архивируемых файлов